### PR TITLE
Add Mix application `:extra_applications` entry for `:xmerl`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Saxmerl.MixProject do
     ]
   end
 
-  def application(), do: []
+  def application(), do: [extra_applications: [:xmerl]]
 
   defp deps() do
     [


### PR DESCRIPTION
On Elixir 1.19 + OTP 28, I was running into build issues like so:

```
> mix deps.clean saxmerl
...
> mix deps.get
...
> mix compile
==> saxmerl
Compiling 4 files (.ex)

== Compilation error in file lib/saxmerl/records.ex ==
** (ArgumentError) lib file xmerl/include/xmerl.hrl could not be found
    (elixir 1.19.5) lib/record/extractor.ex:45: Record.Extractor.from_lib_file/1
    (elixir 1.19.5) lib/record/extractor.ex:22: Record.Extractor.from_or_from_lib_file/1
    (elixir 1.19.5) lib/record/extractor.ex:9: Record.Extractor.extract/2
    lib/saxmerl/records.ex:8: (module)
could not compile dependency :saxmerl, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile saxmerl --force", update it with "mix deps.update saxmerl" or clean it with "mix deps.clean saxmerl"
```

Adding `:xmerl` to the application's `extra_applications` resolves this.